### PR TITLE
Adding marketplace license link

### DIFF
--- a/.azure-pipelines/azure-pipeline.yml
+++ b/.azure-pipelines/azure-pipeline.yml
@@ -40,8 +40,12 @@ stages:
       inputs:
         versionSpec: '13.x'
      # task to print out current path
-    
-  
+    - task: Bash@3
+      inputs:
+        targetType: 'inline'
+        script: |
+          cp ../LICENSE ./
+      
     - template: package.yml@pipeline-templates
       parameters:
         extensionName: $(extensionName)

--- a/.azure-pipelines/azure-pipeline.yml
+++ b/.azure-pipelines/azure-pipeline.yml
@@ -43,6 +43,7 @@ stages:
     - task: Bash@3
       inputs:
         targetType: 'inline'
+        workingDirectory: '$(Build.SourcesDirectory)/Utilites'
         script: |
           cp ../LICENSE ./
       

--- a/Utilites/azure-devops-extension.json
+++ b/Utilites/azure-devops-extension.json
@@ -46,6 +46,9 @@
     "content": {
         "details": {
             "path": "overview.md"
+        },
+        "license": {
+            "path": "../LICENSE"
         }
     },
     "files": [

--- a/Utilites/azure-devops-extension.json
+++ b/Utilites/azure-devops-extension.json
@@ -48,7 +48,7 @@
             "path": "overview.md"
         },
         "license": {
-            "path": "../LICENSE"
+            "path": "LICENSE"
         }
     },
     "files": [


### PR DESCRIPTION
This pull request includes changes to the Azure Pipelines configuration and the Azure DevOps extension configuration to manage the LICENSE file more effectively.

Changes to Azure Pipelines configuration:

* [`.azure-pipelines/azure-pipeline.yml`](diffhunk://#diff-a06df8cb3a8ec3e241d3a83f2bde544138fd078ef2d70770d394648884d47d2eL43-R48): Added a Bash task to copy the LICENSE file from the parent directory to the `Utilites` directory.

Changes to Azure DevOps extension configuration:

* [`Utilites/azure-devops-extension.json`](diffhunk://#diff-eee2cf6f294a9e6b3b9bc29362f43f5f72f6eea933a8daee170a1b7fb03e173aR49-R51): Added a new entry to include the LICENSE file in the extension's content.