### PR TITLE
fix: use npm proxy registry for package resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://packagefeedproxy.microsoft.io/npm/

--- a/Utilites/Shell++/v1/package-lock.json
+++ b/Utilites/Shell++/v1/package-lock.json
@@ -15,7 +15,7 @@
     },
     "node_modules/adm-zip": {
       "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/adm-zip/-/adm-zip-0.5.16.tgz",
       "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "engines": {
         "node": ">=12.0"
@@ -23,7 +23,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dependencies": {
         "debug": "4"
@@ -34,7 +34,7 @@
     },
     "node_modules/azure-pipelines-task-lib": {
       "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.2.tgz",
       "integrity": "sha512-kKG1I2cpHM0kqn/YlnZiA2J59/x4OraEZZ1/Cp6A7XOu0e+E1PfrfldVVOU/tdeW/xOFoexqA4EEV27LfH0YqQ==",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -48,12 +48,12 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -62,12 +62,12 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/debug": {
       "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
         "ms": "^2.1.3"
@@ -83,7 +83,7 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
@@ -102,12 +102,12 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -115,7 +115,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dependencies": {
@@ -135,7 +135,7 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -146,7 +146,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -157,7 +157,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dependencies": {
         "agent-base": "6",
@@ -169,7 +169,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dependencies": {
@@ -179,12 +179,12 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/interpret": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "engines": {
         "node": ">= 0.10"
@@ -192,7 +192,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -206,7 +206,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "engines": {
         "node": ">= 0.6"
@@ -214,7 +214,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -225,7 +225,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -236,12 +236,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
       "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -252,7 +252,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
@@ -268,7 +268,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "engines": {
         "node": ">=0.10.0"
@@ -276,7 +276,7 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path/node_modules/process": {
@@ -299,7 +299,7 @@
     },
     "node_modules/q": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
       "engines": {
@@ -309,7 +309,7 @@
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dependencies": {
         "resolve": "^1.1.6"
@@ -320,7 +320,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -336,7 +336,7 @@
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
       "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
@@ -344,7 +344,7 @@
     },
     "node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
@@ -352,7 +352,7 @@
     },
     "node_modules/shelljs": {
       "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "dependencies": {
         "glob": "^7.0.0",
@@ -368,7 +368,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "engines": {
         "node": ">= 0.4"
@@ -379,7 +379,7 @@
     },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
@@ -387,12 +387,12 @@
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="
     },
     "node_modules/uuid": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
@@ -401,7 +401,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://packagefeedproxy.microsoft.io/npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     }
   }

--- a/Utilites/package-lock.json
+++ b/Utilites/package-lock.json
@@ -15,7 +15,7 @@
         },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@colors/colors/-/colors-1.5.0.tgz",
             "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
             "dev": true,
             "engines": {
@@ -24,7 +24,7 @@
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@isaacs/cliui/-/cliui-8.0.2.tgz",
             "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
             "license": "ISC",
@@ -42,7 +42,7 @@
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
             "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "dev": true,
             "license": "MIT",
@@ -53,7 +53,7 @@
         },
         "node_modules/ansi-regex": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
@@ -66,7 +66,7 @@
         },
         "node_modules/ansi-styles": {
             "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
@@ -79,13 +79,13 @@
         },
         "node_modules/app-root-path": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/app-root-path/-/app-root-path-1.0.0.tgz",
             "integrity": "sha512-OKap/l8oElrynRMEbtwubVW5M5G16LKz9Wxo0DYBmce595lao0EbmD4O82j7qo9yukVWMTDriWvgrbt6yPnb9A==",
             "dev": true
         },
         "node_modules/archiver": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/archiver/-/archiver-2.0.3.tgz",
             "integrity": "sha512-TqHyk3if+6c3elGaLZu+wPMnaY2hm8PYmgmt1J34NZlFyHKwTiSugJFLMfb0K1xbYAgRtDJjjyW3T2p2B1f//g==",
             "dev": true,
             "dependencies": {
@@ -105,7 +105,7 @@
         },
         "node_modules/archiver-utils": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/archiver-utils/-/archiver-utils-1.3.0.tgz",
             "integrity": "sha512-h+hTREBXcW5e1L9RihGXdH4PHHdGipG/jE2sMZrqIH6BmZAxeGU5IWjVsKhokdCSWX7km6Kkh406zZNEElHFPQ==",
             "dev": true,
             "dependencies": {
@@ -122,7 +122,7 @@
         },
         "node_modules/archiver-utils/node_modules/normalize-path": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
             "dev": true,
             "dependencies": {
@@ -134,7 +134,7 @@
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
             "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
             "dev": true,
             "dependencies": {
@@ -147,7 +147,7 @@
         },
         "node_modules/array.prototype.reduce": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.reduce/-/array.prototype.reduce-1.0.6.tgz",
             "integrity": "sha512-UW+Mz8LG/sPSU8jRDCjVr6J/ZKAGpHfwrZ6kWTG5qCxIEiXdVshqGnu5vEZA8S1y6X4aCSbQZ0/EEsfvEvBiSg==",
             "dev": true,
             "dependencies": {
@@ -166,7 +166,7 @@
         },
         "node_modules/arraybuffer.prototype.slice": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
             "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
             "dev": true,
             "dependencies": {
@@ -187,7 +187,7 @@
         },
         "node_modules/async": {
             "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/async/-/async-2.6.4.tgz",
             "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
             "dev": true,
             "dependencies": {
@@ -196,7 +196,7 @@
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
             "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
             "dev": true,
             "engines": {
@@ -208,7 +208,7 @@
         },
         "node_modules/azure-devops-node-api": {
             "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
             "integrity": "sha512-QhpgjH1LQ+vgDJ7oBwcmsZ3+o4ZpjLVilw0D3oJQpYpRzN+L39lk5jZDLJ464hLUgsDzWn/Ksv7zLLMKLfoBzA==",
             "dev": true,
             "license": "MIT",
@@ -222,13 +222,13 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true,
             "funding": [
@@ -248,7 +248,7 @@
         },
         "node_modules/bl": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bl/-/bl-1.2.3.tgz",
             "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
             "dev": true,
             "dependencies": {
@@ -258,7 +258,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-1.1.12.tgz",
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
@@ -269,7 +269,7 @@
         },
         "node_modules/buffer": {
             "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "dev": true,
             "funding": [
@@ -293,7 +293,7 @@
         },
         "node_modules/buffer-alloc": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
             "dependencies": {
@@ -303,13 +303,13 @@
         },
         "node_modules/buffer-alloc-unsafe": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
             "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
             "dev": true
         },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
             "dev": true,
             "engines": {
@@ -318,13 +318,13 @@
         },
         "node_modules/buffer-fill": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-fill/-/buffer-fill-1.0.0.tgz",
             "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
             "dev": true
         },
         "node_modules/call-bind": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind/-/call-bind-1.0.2.tgz",
             "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
             "dev": true,
             "dependencies": {
@@ -337,7 +337,7 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
             "license": "MIT",
@@ -351,7 +351,7 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "dev": true,
             "license": "MIT",
@@ -368,7 +368,7 @@
         },
         "node_modules/clipboardy": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/clipboardy/-/clipboardy-4.0.0.tgz",
             "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
             "dev": true,
             "license": "MIT",
@@ -386,7 +386,7 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
             "license": "MIT",
@@ -399,14 +399,14 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/colors": {
             "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/colors/-/colors-1.3.3.tgz",
             "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
             "dev": true,
             "engines": {
@@ -415,7 +415,7 @@
         },
         "node_modules/compress-commons": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/compress-commons/-/compress-commons-1.2.2.tgz",
             "integrity": "sha512-SLTU8iWWmcORfUN+4351Z2aZXKJe1tr0jSilPMCZlLPzpdTXnkBW1LevW/MfuANBKJek8Xu9ggqrtVmQrChLtg==",
             "dev": true,
             "dependencies": {
@@ -430,7 +430,7 @@
         },
         "node_modules/compress-commons/node_modules/normalize-path": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
             "dev": true,
             "dependencies": {
@@ -442,19 +442,19 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
         },
         "node_modules/crc": {
             "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/crc/-/crc-3.8.0.tgz",
             "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
             "dev": true,
             "dependencies": {
@@ -463,7 +463,7 @@
         },
         "node_modules/crc32-stream": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/crc32-stream/-/crc32-stream-2.0.0.tgz",
             "integrity": "sha512-UjZSqFCbn+jZUHJIh6Y3vMF7EJLcJWNm4tKDf2peJRwlZKHvkkvOMTvAei6zjU9gO1xONVr3rRFw0gixm2eUng==",
             "dev": true,
             "dependencies": {
@@ -476,7 +476,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "license": "MIT",
@@ -491,7 +491,7 @@
         },
         "node_modules/cycle": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cycle/-/cycle-1.0.3.tgz",
             "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==",
             "dev": true,
             "engines": {
@@ -500,7 +500,7 @@
         },
         "node_modules/dateformat": {
             "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/dateformat/-/dateformat-1.0.11.tgz",
             "integrity": "sha512-5zcI+Qoul0QgiCcjzsobs9G1c+vHCNaYB2NGa57ZbVnP7bZeKJJgoM/K+I/obaHAmyEL0J8hJafbQ+HFSZnzZA==",
             "dev": true,
             "dependencies": {
@@ -516,7 +516,7 @@
         },
         "node_modules/define-data-property": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/define-data-property/-/define-data-property-1.1.0.tgz",
             "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
             "dev": true,
             "dependencies": {
@@ -530,7 +530,7 @@
         },
         "node_modules/define-properties": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
             "dev": true,
             "dependencies": {
@@ -547,7 +547,7 @@
         },
         "node_modules/des.js": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/des.js/-/des.js-1.1.0.tgz",
             "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
             "dev": true,
             "license": "MIT",
@@ -558,7 +558,7 @@
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "dev": true,
             "license": "MIT",
@@ -573,21 +573,21 @@
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "dependencies": {
@@ -596,7 +596,7 @@
         },
         "node_modules/es-abstract": {
             "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-abstract/-/es-abstract-1.22.2.tgz",
             "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
             "dev": true,
             "dependencies": {
@@ -649,13 +649,13 @@
         },
         "node_modules/es-array-method-boxes-properly": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
             "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
             "dev": true
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "dev": true,
             "license": "MIT",
@@ -665,7 +665,7 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true,
             "license": "MIT",
@@ -675,7 +675,7 @@
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "dev": true,
             "license": "MIT",
@@ -688,7 +688,7 @@
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
             "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
             "dev": true,
             "dependencies": {
@@ -702,7 +702,7 @@
         },
         "node_modules/es-to-primitive": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "dev": true,
             "dependencies": {
@@ -719,7 +719,7 @@
         },
         "node_modules/execa": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/execa/-/execa-8.0.1.tgz",
             "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
             "dev": true,
             "license": "MIT",
@@ -743,7 +743,7 @@
         },
         "node_modules/eyes": {
             "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eyes/-/eyes-0.1.8.tgz",
             "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
             "dev": true,
             "engines": {
@@ -752,7 +752,7 @@
         },
         "node_modules/for-each": {
             "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/for-each/-/for-each-0.3.3.tgz",
             "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
             "dev": true,
             "dependencies": {
@@ -761,7 +761,7 @@
         },
         "node_modules/foreground-child": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/foreground-child/-/foreground-child-3.1.1.tgz",
             "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
             "dev": true,
             "dependencies": {
@@ -777,19 +777,19 @@
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "dev": true
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true,
             "license": "MIT",
@@ -799,7 +799,7 @@
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
             "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
             "dev": true,
             "dependencies": {
@@ -817,7 +817,7 @@
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/functions-have-names/-/functions-have-names-1.2.3.tgz",
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "dev": true,
             "funding": {
@@ -826,7 +826,7 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "license": "MIT",
@@ -851,7 +851,7 @@
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "dev": true,
             "license": "MIT",
@@ -865,7 +865,7 @@
         },
         "node_modules/get-stdin": {
             "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-stdin/-/get-stdin-9.0.0.tgz",
             "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
             "dev": true,
             "engines": {
@@ -877,7 +877,7 @@
         },
         "node_modules/get-stream": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-stream/-/get-stream-8.0.1.tgz",
             "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
             "dev": true,
             "license": "MIT",
@@ -890,7 +890,7 @@
         },
         "node_modules/get-symbol-description": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
             "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
             "dev": true,
             "dependencies": {
@@ -906,7 +906,7 @@
         },
         "node_modules/glob": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "dependencies": {
@@ -923,7 +923,7 @@
         },
         "node_modules/globalthis": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/globalthis/-/globalthis-1.0.3.tgz",
             "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
             "dev": true,
             "dependencies": {
@@ -938,7 +938,7 @@
         },
         "node_modules/gopd": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true,
             "license": "MIT",
@@ -951,13 +951,13 @@
         },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/has": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has/-/has-1.0.4.tgz",
             "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
             "dev": true,
             "engines": {
@@ -966,7 +966,7 @@
         },
         "node_modules/has-bigints": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-bigints/-/has-bigints-1.0.2.tgz",
             "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
             "dev": true,
             "funding": {
@@ -975,7 +975,7 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
             "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
             "dev": true,
             "dependencies": {
@@ -987,7 +987,7 @@
         },
         "node_modules/has-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-proto/-/has-proto-1.0.1.tgz",
             "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
             "dev": true,
             "engines": {
@@ -999,7 +999,7 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
             "license": "MIT",
@@ -1012,7 +1012,7 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
             "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
             "dev": true,
             "dependencies": {
@@ -1027,7 +1027,7 @@
         },
         "node_modules/hasown": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dev": true,
             "license": "MIT",
@@ -1040,7 +1040,7 @@
         },
         "node_modules/human-signals": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/human-signals/-/human-signals-5.0.0.tgz",
             "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
             "dev": true,
             "license": "Apache-2.0",
@@ -1050,7 +1050,7 @@
         },
         "node_modules/ieee754": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "dev": true,
             "funding": [
@@ -1070,13 +1070,13 @@
         },
         "node_modules/immediate": {
             "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/immediate/-/immediate-3.0.6.tgz",
             "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
             "dev": true
         },
         "node_modules/inflight": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "dev": true,
             "dependencies": {
@@ -1086,13 +1086,13 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
         "node_modules/internal-slot": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/internal-slot/-/internal-slot-1.0.5.tgz",
             "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
             "dev": true,
             "dependencies": {
@@ -1106,7 +1106,7 @@
         },
         "node_modules/interpret": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true,
             "engines": {
@@ -1115,7 +1115,7 @@
         },
         "node_modules/is-array-buffer": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
             "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
             "dev": true,
             "dependencies": {
@@ -1129,7 +1129,7 @@
         },
         "node_modules/is-bigint": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-bigint/-/is-bigint-1.0.4.tgz",
             "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
             "dev": true,
             "dependencies": {
@@ -1141,7 +1141,7 @@
         },
         "node_modules/is-boolean-object": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
             "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
             "dev": true,
             "dependencies": {
@@ -1157,7 +1157,7 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "dev": true,
             "engines": {
@@ -1169,7 +1169,7 @@
         },
         "node_modules/is-core-module": {
             "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-core-module/-/is-core-module-2.13.0.tgz",
             "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
             "dev": true,
             "dependencies": {
@@ -1181,7 +1181,7 @@
         },
         "node_modules/is-date-object": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-date-object/-/is-date-object-1.0.5.tgz",
             "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
             "dev": true,
             "dependencies": {
@@ -1196,7 +1196,7 @@
         },
         "node_modules/is-docker": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-docker/-/is-docker-3.0.0.tgz",
             "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "dev": true,
             "license": "MIT",
@@ -1212,7 +1212,7 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "license": "MIT",
@@ -1222,7 +1222,7 @@
         },
         "node_modules/is-inside-container": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-inside-container/-/is-inside-container-1.0.0.tgz",
             "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
             "dev": true,
             "license": "MIT",
@@ -1241,7 +1241,7 @@
         },
         "node_modules/is-negative-zero": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
             "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
             "dev": true,
             "engines": {
@@ -1253,7 +1253,7 @@
         },
         "node_modules/is-number-object": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-number-object/-/is-number-object-1.0.7.tgz",
             "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
             "dev": true,
             "dependencies": {
@@ -1268,7 +1268,7 @@
         },
         "node_modules/is-regex": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-regex/-/is-regex-1.1.4.tgz",
             "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
             "dev": true,
             "dependencies": {
@@ -1284,7 +1284,7 @@
         },
         "node_modules/is-shared-array-buffer": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
             "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
             "dev": true,
             "dependencies": {
@@ -1296,7 +1296,7 @@
         },
         "node_modules/is-stream": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-stream/-/is-stream-3.0.0.tgz",
             "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
             "dev": true,
             "license": "MIT",
@@ -1309,7 +1309,7 @@
         },
         "node_modules/is-string": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-string/-/is-string-1.0.7.tgz",
             "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
             "dev": true,
             "dependencies": {
@@ -1324,7 +1324,7 @@
         },
         "node_modules/is-symbol": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-symbol/-/is-symbol-1.0.4.tgz",
             "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
             "dev": true,
             "dependencies": {
@@ -1339,7 +1339,7 @@
         },
         "node_modules/is-typed-array": {
             "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-typed-array/-/is-typed-array-1.1.12.tgz",
             "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
             "dev": true,
             "dependencies": {
@@ -1354,7 +1354,7 @@
         },
         "node_modules/is-weakref": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakref/-/is-weakref-1.0.2.tgz",
             "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
             "dev": true,
             "dependencies": {
@@ -1366,7 +1366,7 @@
         },
         "node_modules/is-wsl": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-wsl/-/is-wsl-3.1.0.tgz",
             "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
             "dev": true,
             "license": "MIT",
@@ -1382,7 +1382,7 @@
         },
         "node_modules/is64bit": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is64bit/-/is64bit-2.0.0.tgz",
             "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
             "dev": true,
             "license": "MIT",
@@ -1398,26 +1398,26 @@
         },
         "node_modules/isarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/isstream": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "dev": true
         },
         "node_modules/jackspeak": {
             "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jackspeak/-/jackspeak-3.4.3.tgz",
             "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -1433,20 +1433,20 @@
         },
         "node_modules/jju": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jju/-/jju-1.4.0.tgz",
             "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
             "dev": true
         },
         "node_modules/js-md4": {
             "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/js-md4/-/js-md4-0.3.2.tgz",
             "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/json-in-place": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-in-place/-/json-in-place-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-in-place/-/json-in-place-1.0.1.tgz",
             "integrity": "sha512-XDFWT1iOlZErTFU0GGRju9g/uzY8BVFVsGsbgiE71Fg2+3c0lK4X4GSRB8PQ527hVkAJ2Z5Qv2sa7Re9iFNYKw==",
             "dev": true,
             "dependencies": {
@@ -1455,13 +1455,13 @@
         },
         "node_modules/json-lexer": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/json-lexer/-/json-lexer-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-lexer/-/json-lexer-1.1.1.tgz",
             "integrity": "sha512-kdpvcH1gqYXQEAVFxVwIWZKihrS0o9SjbwW2v8+0p6HA/YSMk5c4BkXdMiz/kDz2QW0XlOSkFKrJsC9KL0Mb5g==",
             "dev": true
         },
         "node_modules/jszip": {
             "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jszip/-/jszip-3.10.1.tgz",
             "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
             "dev": true,
             "dependencies": {
@@ -1473,7 +1473,7 @@
         },
         "node_modules/lazystream": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lazystream/-/lazystream-1.0.1.tgz",
             "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
             "dev": true,
             "dependencies": {
@@ -1485,7 +1485,7 @@
         },
         "node_modules/lie": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lie/-/lie-3.3.0.tgz",
             "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
             "dev": true,
             "dependencies": {
@@ -1494,20 +1494,20 @@
         },
         "node_modules/lodash": {
             "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "node_modules/lru-cache": {
             "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "dev": true,
             "license": "MIT",
@@ -1517,7 +1517,7 @@
         },
         "node_modules/meow": {
             "version": "12.1.1",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/meow/-/meow-12.1.1.tgz",
             "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
             "dev": true,
             "engines": {
@@ -1529,14 +1529,14 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/mimic-fn": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mimic-fn/-/mimic-fn-4.0.0.tgz",
             "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
             "dev": true,
             "license": "MIT",
@@ -1549,14 +1549,14 @@
         },
         "node_modules/minimalistic-assert": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
             "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "dependencies": {
@@ -1568,7 +1568,7 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
             "funding": {
@@ -1577,7 +1577,7 @@
         },
         "node_modules/minipass": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minipass/-/minipass-7.1.2.tgz",
             "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "license": "ISC",
@@ -1587,7 +1587,7 @@
         },
         "node_modules/mkdirp": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
             "dev": true,
             "bin": {
@@ -1599,13 +1599,13 @@
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
         "node_modules/npm-run-path": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/npm-run-path/-/npm-run-path-5.3.0.tgz",
             "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
             "dev": true,
             "license": "MIT",
@@ -1621,7 +1621,7 @@
         },
         "node_modules/npm-run-path/node_modules/path-key": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-key/-/path-key-4.0.0.tgz",
             "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
             "dev": true,
             "license": "MIT",
@@ -1634,7 +1634,7 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "dev": true,
             "license": "MIT",
@@ -1647,7 +1647,7 @@
         },
         "node_modules/object-keys": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "dev": true,
             "engines": {
@@ -1656,7 +1656,7 @@
         },
         "node_modules/object.assign": {
             "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object.assign/-/object.assign-4.1.4.tgz",
             "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
             "dev": true,
             "dependencies": {
@@ -1674,7 +1674,7 @@
         },
         "node_modules/object.getownpropertydescriptors": {
             "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.7.tgz",
             "integrity": "sha512-PrJz0C2xJ58FNn11XV2lr4Jt5Gzl94qpy9Lu0JlfEj14z88sqbSBJCBEzdlNUCzY2gburhbrwOZ5BHCmuNUy0g==",
             "dev": true,
             "dependencies": {
@@ -1693,7 +1693,7 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "dependencies": {
@@ -1702,7 +1702,7 @@
         },
         "node_modules/onecolor": {
             "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/onecolor/-/onecolor-2.5.0.tgz",
             "integrity": "sha512-OdUvcyPnJ+o35vXb6RIY3fxJITm+EGcfFECanoOKnISTFG+Pl/I1n5TcbxH+KHC310+RopEG4Cccz+naDWAD2A==",
             "dev": true,
             "engines": {
@@ -1711,7 +1711,7 @@
         },
         "node_modules/onetime": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/onetime/-/onetime-6.0.0.tgz",
             "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
             "dev": true,
             "license": "MIT",
@@ -1727,7 +1727,7 @@
         },
         "node_modules/os-homedir": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
             "dev": true,
             "engines": {
@@ -1736,20 +1736,20 @@
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
         "node_modules/pako": {
             "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pako/-/pako-1.0.11.tgz",
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
             "engines": {
@@ -1758,7 +1758,7 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
             "license": "MIT",
@@ -1768,13 +1768,13 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
         "node_modules/path-scurry": {
             "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -1791,13 +1791,13 @@
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
         "node_modules/prompt": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/prompt/-/prompt-1.3.0.tgz",
             "integrity": "sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==",
             "dev": true,
             "dependencies": {
@@ -1813,13 +1813,13 @@
         },
         "node_modules/prompt/node_modules/async": {
             "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/async/-/async-3.2.3.tgz",
             "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
             "dev": true
         },
         "node_modules/qs": {
             "version": "6.14.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/qs/-/qs-6.14.1.tgz",
             "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -1835,7 +1835,7 @@
         },
         "node_modules/read": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/read/-/read-1.0.7.tgz",
             "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
             "dev": true,
             "dependencies": {
@@ -1847,7 +1847,7 @@
         },
         "node_modules/readable-stream": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "dependencies": {
@@ -1862,13 +1862,13 @@
         },
         "node_modules/readable-stream/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
             "dev": true,
             "dependencies": {
@@ -1880,7 +1880,7 @@
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
             "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
             "dev": true,
             "dependencies": {
@@ -1897,13 +1897,13 @@
         },
         "node_modules/remove-trailing-separator": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
             "dev": true
         },
         "node_modules/resolve": {
             "version": "1.22.6",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve/-/resolve-1.22.6.tgz",
             "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
             "dev": true,
             "dependencies": {
@@ -1920,7 +1920,7 @@
         },
         "node_modules/revalidator": {
             "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/revalidator/-/revalidator-0.1.8.tgz",
             "integrity": "sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==",
             "dev": true,
             "engines": {
@@ -1929,7 +1929,7 @@
         },
         "node_modules/rimraf": {
             "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rimraf/-/rimraf-5.0.5.tgz",
             "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
             "dev": true,
             "dependencies": {
@@ -1947,7 +1947,7 @@
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/brace-expansion/-/brace-expansion-2.0.2.tgz",
             "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
@@ -1957,7 +1957,7 @@
         },
         "node_modules/rimraf/node_modules/glob": {
             "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "dev": true,
             "license": "ISC",
@@ -1978,7 +1978,7 @@
         },
         "node_modules/rimraf/node_modules/minimatch": {
             "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-9.0.5.tgz",
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
@@ -1994,7 +1994,7 @@
         },
         "node_modules/safe-array-concat": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
             "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
             "dev": true,
             "dependencies": {
@@ -2012,13 +2012,13 @@
         },
         "node_modules/safe-array-concat/node_modules/isarray": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
             "dev": true
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true,
             "funding": [
@@ -2038,7 +2038,7 @@
         },
         "node_modules/safe-regex-test": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
             "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
             "dev": true,
             "dependencies": {
@@ -2052,13 +2052,13 @@
         },
         "node_modules/sax": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/sax/-/sax-1.3.0.tgz",
             "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
             "dev": true
         },
         "node_modules/set-function-name": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/set-function-name/-/set-function-name-2.0.1.tgz",
             "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
             "dev": true,
             "dependencies": {
@@ -2072,13 +2072,13 @@
         },
         "node_modules/setimmediate": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/setimmediate/-/setimmediate-1.0.5.tgz",
             "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
             "dev": true
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
             "license": "MIT",
@@ -2091,7 +2091,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
             "license": "MIT",
@@ -2101,7 +2101,7 @@
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shelljs/-/shelljs-0.8.5.tgz",
             "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
             "dev": true,
             "dependencies": {
@@ -2118,7 +2118,7 @@
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "dev": true,
             "license": "MIT",
@@ -2138,7 +2138,7 @@
         },
         "node_modules/side-channel-list": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
             "dev": true,
             "license": "MIT",
@@ -2155,7 +2155,7 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "dev": true,
             "license": "MIT",
@@ -2174,7 +2174,7 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "dev": true,
             "license": "MIT",
@@ -2194,7 +2194,7 @@
         },
         "node_modules/signal-exit": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
             "license": "ISC",
@@ -2207,7 +2207,7 @@
         },
         "node_modules/stack-trace": {
             "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/stack-trace/-/stack-trace-0.0.10.tgz",
             "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
             "dev": true,
             "engines": {
@@ -2216,7 +2216,7 @@
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "dependencies": {
@@ -2225,13 +2225,13 @@
         },
         "node_modules/string_decoder/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
         "node_modules/string-width": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-5.1.2.tgz",
             "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
             "license": "MIT",
@@ -2250,7 +2250,7 @@
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
@@ -2265,7 +2265,7 @@
         },
         "node_modules/string-width-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -2275,14 +2275,14 @@
         },
         "node_modules/string-width-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -2295,7 +2295,7 @@
         },
         "node_modules/string.prototype.trim": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
             "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
             "dev": true,
             "dependencies": {
@@ -2312,7 +2312,7 @@
         },
         "node_modules/string.prototype.trimend": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
             "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
             "dev": true,
             "dependencies": {
@@ -2326,7 +2326,7 @@
         },
         "node_modules/string.prototype.trimstart": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
             "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
             "dev": true,
             "dependencies": {
@@ -2340,7 +2340,7 @@
         },
         "node_modules/strip-ansi": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "dev": true,
             "license": "MIT",
@@ -2357,7 +2357,7 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -2370,7 +2370,7 @@
         },
         "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -2380,7 +2380,7 @@
         },
         "node_modules/strip-final-newline": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
             "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
             "dev": true,
             "license": "MIT",
@@ -2393,7 +2393,7 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true,
             "engines": {
@@ -2405,7 +2405,7 @@
         },
         "node_modules/system-architecture": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/system-architecture/-/system-architecture-0.1.0.tgz",
             "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
             "dev": true,
             "license": "MIT",
@@ -2418,7 +2418,7 @@
         },
         "node_modules/tar-stream": {
             "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tar-stream/-/tar-stream-1.6.2.tgz",
             "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
             "dev": true,
             "dependencies": {
@@ -2436,7 +2436,7 @@
         },
         "node_modules/tfx-cli": {
             "version": "0.22.1",
-            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.22.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tfx-cli/-/tfx-cli-0.22.1.tgz",
             "integrity": "sha512-LhKzq0HJ7/kznsoCsoX+wqeYzHCfS0RuBMT4g6/pEZ+cPPZZIKC55Nh+0XwjaruVVoMuuK5BrNk2QHS6gDfk5Q==",
             "dev": true,
             "license": "MIT",
@@ -2475,7 +2475,7 @@
         },
         "node_modules/tinytim": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/tinytim/-/tinytim-0.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tinytim/-/tinytim-0.1.1.tgz",
             "integrity": "sha512-NIpsp9lBIxPNzB++HnMmUd4byzJSVbbO4F+As1Gb1IG/YQT5QvmBDjpx8SpDS8fhGC+t+Qw8ldQgbcAIaU+2cA==",
             "dev": true,
             "engines": {
@@ -2484,7 +2484,7 @@
         },
         "node_modules/tmp": {
             "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tmp/-/tmp-0.2.5.tgz",
             "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
             "dev": true,
             "license": "MIT",
@@ -2494,13 +2494,13 @@
         },
         "node_modules/to-buffer": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/to-buffer/-/to-buffer-1.1.1.tgz",
             "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
             "dev": true
         },
         "node_modules/tracer": {
             "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/tracer/-/tracer-0.7.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tracer/-/tracer-0.7.4.tgz",
             "integrity": "sha512-yG3Yb4ztlE1CZHNRWcBqjRIVSCXd8fx7HvL9gvlC37tpPrG3I5skNAY3mQApWeQiw0/3m83JWbfagwOAlmP/ww==",
             "dev": true,
             "dependencies": {
@@ -2514,7 +2514,7 @@
         },
         "node_modules/tracer/node_modules/colors": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/colors/-/colors-1.0.3.tgz",
             "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
             "dev": true,
             "engines": {
@@ -2523,7 +2523,7 @@
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "dev": true,
             "license": "MIT",
@@ -2533,7 +2533,7 @@
         },
         "node_modules/typed-array-buffer": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
             "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
             "dev": true,
             "dependencies": {
@@ -2547,7 +2547,7 @@
         },
         "node_modules/typed-array-byte-length": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
             "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
             "dev": true,
             "dependencies": {
@@ -2565,7 +2565,7 @@
         },
         "node_modules/typed-array-byte-offset": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
             "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
             "dev": true,
             "dependencies": {
@@ -2584,7 +2584,7 @@
         },
         "node_modules/typed-array-length": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-length/-/typed-array-length-1.0.4.tgz",
             "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
             "dev": true,
             "dependencies": {
@@ -2598,7 +2598,7 @@
         },
         "node_modules/typed-rest-client": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
             "integrity": "sha512-Nel9aPbgSzRxfs1+4GoSB4wexCF+4Axlk7OSGVQCMa+4fWcyxIsN/YNmkp0xTT2iQzMD98h8yFLav/cNaULmRA==",
             "dev": true,
             "license": "MIT",
@@ -2615,7 +2615,7 @@
         },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
             "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
             "dev": true,
             "dependencies": {
@@ -2630,20 +2630,20 @@
         },
         "node_modules/underscore": {
             "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/underscore/-/underscore-1.13.7.tgz",
             "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
         "node_modules/util.promisify": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/util.promisify/-/util.promisify-1.1.2.tgz",
             "integrity": "sha512-PBdZ03m1kBnQ5cjjO0ZvJMJS+QsbyIcFwi4hY4U76OQsCO9JrOYjbCFgIF76ccFg9xnJo7ZHPkqyj1GqmdS7MA==",
             "dev": true,
             "dependencies": {
@@ -2661,7 +2661,7 @@
         },
         "node_modules/uuid": {
             "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
             "dev": true,
@@ -2671,7 +2671,7 @@
         },
         "node_modules/validator": {
             "version": "13.15.23",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/validator/-/validator-13.15.23.tgz",
             "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
             "dev": true,
             "license": "MIT",
@@ -2681,7 +2681,7 @@
         },
         "node_modules/walkdir": {
             "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/walkdir/-/walkdir-0.0.11.tgz",
             "integrity": "sha512-lMFYXGpf7eg+RInVL021ZbJJT4hqsvsBvq5sZBp874jfhs3IWlA7OPoG0ojQrYcXHuUSi+Nqp6qGN+pPGaMgPQ==",
             "dev": true,
             "engines": {
@@ -2690,7 +2690,7 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "license": "ISC",
@@ -2706,7 +2706,7 @@
         },
         "node_modules/which-boxed-primitive": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
             "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
             "dev": true,
             "dependencies": {
@@ -2722,7 +2722,7 @@
         },
         "node_modules/which-typed-array": {
             "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which-typed-array/-/which-typed-array-1.1.11.tgz",
             "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
             "dev": true,
             "dependencies": {
@@ -2741,13 +2741,13 @@
         },
         "node_modules/winreg": {
             "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/winreg/-/winreg-0.0.12.tgz",
             "integrity": "sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==",
             "dev": true
         },
         "node_modules/winston": {
             "version": "2.4.7",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/winston/-/winston-2.4.7.tgz",
             "integrity": "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==",
             "dev": true,
             "dependencies": {
@@ -2764,7 +2764,7 @@
         },
         "node_modules/winston/node_modules/colors": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/colors/-/colors-1.0.3.tgz",
             "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
             "dev": true,
             "engines": {
@@ -2773,7 +2773,7 @@
         },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
             "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "dev": true,
             "license": "MIT",
@@ -2792,7 +2792,7 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
@@ -2810,7 +2810,7 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -2820,7 +2820,7 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
             "license": "MIT",
@@ -2836,14 +2836,14 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
@@ -2858,7 +2858,7 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -2871,13 +2871,13 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
         },
         "node_modules/xml2js": {
             "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/xml2js/-/xml2js-0.5.0.tgz",
             "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
             "dev": true,
             "dependencies": {
@@ -2890,7 +2890,7 @@
         },
         "node_modules/xmlbuilder": {
             "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "dev": true,
             "engines": {
@@ -2899,7 +2899,7 @@
         },
         "node_modules/xtend": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "dev": true,
             "engines": {
@@ -2908,7 +2908,7 @@
         },
         "node_modules/zip-stream": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/zip-stream/-/zip-stream-1.2.0.tgz",
             "integrity": "sha512-2olrDUuPM4NvRIgGPhvrp84f7/HmWR6RiQrgwFF2VctmnssFiogtYL3DcA8Vl2bsSmju79sVXe38TsII7JleUg==",
             "dev": true,
             "dependencies": {


### PR DESCRIPTION
## Summary
Resolves security alerts caused by direct access to npmjs.org.

## Changes
- Added .npmrc at repo root with proxy registry:
  `registry=https://packagefeedproxy.microsoft.io/npm/`
- Updated all package-lock.json resolved URLs from egistry.npmjs.org to packagefeedproxy.microsoft.io/npm (host-only change, identical path structure).

## Verification
Run `npm ci` to verify packages resolve correctly through the proxy.